### PR TITLE
Fix chat column width overflow

### DIFF
--- a/src/features/Room/Messages/Message/Message.tsx
+++ b/src/features/Room/Messages/Message/Message.tsx
@@ -161,10 +161,10 @@ const Message = forwardRef<any, MessageProps>(
             contentVisibility: "auto",
           }}
           tabIndex={1}
-          className="flex flex-col transition-all"
+          className="min-w-0 flex flex-col transition-all"
         >
           <div
-            className={`relative flex gap-1.5  ${
+            className={`relative flex min-w-0 gap-1.5  ${
               isMine ? "flex-row-reverse" : ""
             } items-end transition-all focus:outline-0  focus:outline-slate-600 
           
@@ -238,7 +238,7 @@ const Message = forwardRef<any, MessageProps>(
                   });
                 }
               }}
-              className={`flex flex-col ${
+              className={`min-w-0 flex flex-col ${
                 isMine ? "items-end" : "items-start"
               } gap-1`}
             >

--- a/src/features/Room/Messages/Message/MessageBubble.tsx
+++ b/src/features/Room/Messages/Message/MessageBubble.tsx
@@ -26,7 +26,7 @@ const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps>(
       <div className="relative">
         <div
           ref={messageRef}
-          className={`pointer-events-none relative flex min-w-[3rem] max-w-[80vw]  select-none flex-col 
+          className={`pointer-events-none relative flex min-w-0 max-w-[min(80vw,100%)] select-none flex-col 
                 gap-1 rounded-3xl px-3 pb-1  pt-2 @container-normal  sm:max-w-[20rem]
                 ${
                   isMine
@@ -52,8 +52,8 @@ const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps>(
                 
                 `}
         >
-          <div className="flex flex-col justify-between text-[0.9rem] leading-relaxed tracking-wide">
-            <pre className=" whitespace-pre-wrap font-sans">
+          <div className="min-w-0 flex flex-col justify-between text-[0.9rem] leading-relaxed tracking-wide">
+            <pre className="whitespace-pre-wrap break-words font-sans [overflow-wrap:anywhere]">
               <Highlight query={search} styles={{ py: "1", bg: "orange.100" }}>
                 {message.body}
               </Highlight>

--- a/src/features/Room/Messages/MessageList.tsx
+++ b/src/features/Room/Messages/MessageList.tsx
@@ -29,11 +29,11 @@ function MessageList({}: MessagesProps) {
   return (
     <div
       ref={messageListRef}
-      className="relative grow self-stretch overflow-y-auto overflow-x-hidden"
+      className="relative min-w-0 grow self-stretch overflow-y-auto overflow-x-hidden"
     >
       <div
         id="messages-container"
-        className="flex h-full grow flex-col-reverse self-stretch overflow-x-hidden overflow-y-scroll p-2 pb-4"
+        className="flex h-full min-w-0 grow flex-col-reverse self-stretch overflow-x-hidden overflow-y-scroll p-2 pb-4"
       >
         {messages.length > 0 ? (
           <MessageListContext.Provider

--- a/src/features/Room/Room.tsx
+++ b/src/features/Room/Room.tsx
@@ -33,7 +33,7 @@ function Room() {
   return (
     <>
       <Box
-        className={`grid h-full grow grid-rows-[1fr_6fr_0.5fr] bg-gray2 dark:bg-dark-blue1`}
+        className={`grid h-full min-w-0 flex-1 grid-rows-[1fr_6fr_0.5fr] bg-gray2 dark:bg-dark-blue1`}
       >
         <ChatHeader key={`header-${selectedChat.$id}`} />
         <MessagesList key={`messagesList-${selectedChat.$id}`}></MessagesList>
@@ -42,7 +42,7 @@ function Room() {
       <aside
         className={`hidden ${
           showDetails && "absolute inset-0"
-        } flex  grow basis-40 flex-col items-center border-l pb-4 pt-6 transition-all dark:border-dark-slate4 md:static xl:flex`}
+        } flex shrink-0 basis-40 flex-col items-center border-l pb-4 pt-6 transition-all dark:border-dark-slate4 md:static xl:flex`}
       >
         <RoomDetails />
         <RoomDetailsFooter />

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -16,7 +16,7 @@ function Chats() {
         <ConversationList className="" />
       </Sidebar>
       <Box
-        className={`absolute inset-0 flex h-full grow transition-opacity md:relative ${
+        className={`absolute inset-0 flex h-full min-w-0 flex-1 transition-opacity md:relative ${
           selectedChat ? "z-10" : "invisible md:visible"
         }`}
       >


### PR DESCRIPTION
## Summary
- Constrain the chat layout with `min-w-0` and `flex-1` so the room column stays fixed to the viewport width.
- Prevent long message content from widening the layout by allowing bubbles and message text to wrap within their container.
- Keep the details sidebar from participating in width growth.

## Testing
- `npm run build`