### PR TITLE
Pin Node 24 for Vercel builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "24.x"
+  },
   "scripts": {
     "dev": "vite --host",
     "build": "tsc && vite build",


### PR DESCRIPTION
## Summary
- Pin the project Node runtime to `24.x` in `package.json` so Vercel uses a supported version during builds.

## Testing
- Not run (not requested)