### PR TITLE
Fix room details column width

### DIFF
--- a/src/features/Room/Room.tsx
+++ b/src/features/Room/Room.tsx
@@ -42,7 +42,7 @@ function Room() {
       <aside
         className={`hidden ${
           showDetails && "absolute inset-0"
-        } flex shrink-0 basis-40 flex-col items-center border-l pb-4 pt-6 transition-all dark:border-dark-slate4 md:static xl:flex`}
+        } flex w-80 shrink-0 flex-col items-center border-l pb-4 pt-6 transition-all dark:border-dark-slate4 md:static xl:flex`}
       >
         <RoomDetails />
         <RoomDetailsFooter />


### PR DESCRIPTION
## Summary
- keep the room details pane at a fixed width so it does not get squished
- preserve the flexible chat column sizing from the layout fix

## Test
- npm run build