### PR TITLE
Raise visible message reactions above adjacent bubbles

### DIFF
--- a/src/features/Room/Messages/Message/Message.tsx
+++ b/src/features/Room/Messages/Message/Message.tsx
@@ -59,6 +59,7 @@ const Message = forwardRef<any, MessageProps>(
     const { roomState, dispatch } = useRoomContext();
     const [showHoverCard, setShowHoverCard] = useState(false);
     const [showMenu, setShowMenu] = useState(false);
+    const [showReactions, setShowReactions] = useState(false);
     const isOptimistic = !!message?.optimistic;
     if (!currentUserDetails || !selectedChat) return;
 
@@ -159,9 +160,10 @@ const Message = forwardRef<any, MessageProps>(
           }}
           style={{
             contentVisibility: "auto",
+            zIndex: showReactions ? 1000 - i : 0,
           }}
           tabIndex={1}
-          className="min-w-0 flex flex-col transition-all"
+          className="relative min-w-0 flex flex-col transition-all"
         >
           <div
             className={`relative flex min-w-0 gap-1.5  ${
@@ -250,6 +252,7 @@ const Message = forwardRef<any, MessageProps>(
                 message={message}
                 next={next}
                 prev={prev}
+                onReactionVisibilityChange={setShowReactions}
                 ref={messageRef}
               />
             </div>

--- a/src/features/Room/Messages/Message/Message.tsx
+++ b/src/features/Room/Messages/Message/Message.tsx
@@ -159,7 +159,7 @@ const Message = forwardRef<any, MessageProps>(
             setShowHoverCard(false);
           }}
           style={{
-            contentVisibility: "auto",
+            contentVisibility: showReactions ? "visible" : "auto",
             zIndex: showReactions ? 1000 - i : 0,
           }}
           tabIndex={1}

--- a/src/features/Room/Messages/Message/MessageBubble.tsx
+++ b/src/features/Room/Messages/Message/MessageBubble.tsx
@@ -12,9 +12,10 @@ type MessageBubbleProps = {
   message: ChatMessage;
   prev: ChatMessage | undefined;
   next: ChatMessage | undefined;
+  onReactionVisibilityChange?: (isVisible: boolean) => void;
 };
 const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps>(
-  ({ message, prev, next }, messageRef) => {
+  ({ message, prev, next, onReactionVisibilityChange }, messageRef) => {
     const { currentUserDetails } = useAuth();
     const { search } = useMessagesContext();
     const isMine = message.senderID === currentUserDetails?.$id;
@@ -85,10 +86,13 @@ const MessageBubble = forwardRef<HTMLDivElement, MessageBubbleProps>(
             </small>
           </div>
         </div>
-        <div className={`absolute -bottom-3 ${isMine ? "-start-4" : "-end-4"}`}>
+        <div
+          className={`absolute -bottom-3 z-20 ${isMine ? "-start-4" : "-end-4"}`}
+        >
           <MessageReactions
             message={message}
             hoverCardShowing={showHoverCard}
+            onVisibilityChange={onReactionVisibilityChange}
           />
         </div>
       </div>

--- a/src/features/Room/Messages/Message/MessageReactions.tsx
+++ b/src/features/Room/Messages/Message/MessageReactions.tsx
@@ -13,17 +13,19 @@ import {
 } from "@/services/groupMessageServices";
 import { ChatMessage } from "@/types/interfaces";
 import { Button, useColorMode } from "@chakra-ui/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useDebouncedCallback } from "use-debounce";
 
 interface MessageReactionsProps {
   message: ChatMessage;
   hoverCardShowing: boolean;
+  onVisibilityChange?: (isVisible: boolean) => void;
 }
 
 const MessageReactions = ({
   message,
   hoverCardShowing,
+  onVisibilityChange,
 }: MessageReactionsProps) => {
   const { currentUserDetails } = useAuth();
 
@@ -131,9 +133,15 @@ const MessageReactions = ({
     return false;
   }
 
+  const showReactions = shouldShowReactions();
+
+  useEffect(() => {
+    onVisibilityChange?.(showReactions);
+  }, [onVisibilityChange, showReactions]);
+
   return (
     <Button
-      visibility={shouldShowReactions() ? "visible" : "hidden"}
+      visibility={showReactions ? "visible" : "hidden"}
       onClick={(e) => {
         e.stopPropagation();
         handleLike();


### PR DESCRIPTION
## Summary
- Added reaction visibility tracking so the owning message row can rise above neighboring rows when the reaction button is shown.
- Set an explicit z-index on the reaction anchor and the message container to prevent the next bubble from overlapping the reaction UI.
- Kept the behavior scoped to the message/reaction components with no broader layout changes.

## Testing
- Built the app locally with `npm run build`.
- Verified TypeScript and production bundling passed without new errors.