### PR TITLE
Replace mobile hamburger with bottom navigation tabs

### DIFF
--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -19,30 +19,25 @@ function MobileNav() {
   ];
 
   return (
-    <nav className="fixed inset-x-3 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 mx-auto max-w-md rounded-3xl border border-white/60 bg-white/70 p-1.5 shadow-[0_18px_50px_rgba(15,23,42,0.24)] backdrop-blur-2xl dark:border-white/10 dark:bg-dark-slate3/70 md:hidden">
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-slate4 dark:bg-dark-blue2 md:hidden">
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {
-          const isActive =
-            pathname === link.value || pathname.startsWith(`${link.value}/`);
+          const isActive = pathname
+            .split("/")
+            .includes(link.value.substring(1));
 
           return (
             <Link
               to={link.value}
               key={link.value}
               aria-current={isActive ? "page" : undefined}
-              className={`relative flex min-h-14 flex-col items-center justify-center gap-1 rounded-2xl px-1 text-xs font-semibold transition-all duration-200 ${
+              className={`flex min-h-12 flex-col items-center justify-center gap-1 rounded-md px-1 text-xs font-semibold transition-colors ${
                 isActive
-                  ? "-translate-y-1 bg-white/85 text-indigo11 shadow-[0_10px_28px_rgba(63,81,181,0.24),inset_0_1px_0_rgba(255,255,255,0.85)] ring-1 ring-indigo6/60 dark:bg-dark-slate2/90 dark:text-dark-indigo11 dark:shadow-[0_10px_28px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.08)] dark:ring-dark-indigo6/70"
-                  : "text-gray11 hover:bg-white/45 hover:text-indigo11 dark:text-gray7 dark:hover:bg-white/10 dark:hover:text-dark-indigo11"
+                  ? "bg-indigo4 text-indigo11 dark:bg-dark-indigo4 dark:text-dark-indigo11"
+                  : "text-gray11 hover:bg-gray4 hover:text-indigo11 dark:text-gray7 dark:hover:bg-dark-slate4 dark:hover:text-dark-indigo11"
               }`}
             >
-              <span
-                className={`transition-transform duration-200 ${
-                  isActive ? "scale-105" : ""
-                }`}
-              >
-                {link.icon}
-              </span>
+              {link.icon}
               <span>{link.title}</span>
             </Link>
           );

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -19,25 +19,30 @@ function MobileNav() {
   ];
 
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-slate4 dark:bg-dark-blue2 md:hidden">
+    <nav className="fixed inset-x-3 bottom-[calc(0.75rem+env(safe-area-inset-bottom))] z-50 mx-auto max-w-md rounded-3xl border border-white/60 bg-white/70 p-1.5 shadow-[0_18px_50px_rgba(15,23,42,0.24)] backdrop-blur-2xl dark:border-white/10 dark:bg-dark-slate3/70 md:hidden">
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {
-          const isActive = pathname
-            .split("/")
-            .includes(link.value.substring(1));
+          const isActive =
+            pathname === link.value || pathname.startsWith(`${link.value}/`);
 
           return (
             <Link
               to={link.value}
               key={link.value}
               aria-current={isActive ? "page" : undefined}
-              className={`flex min-h-12 flex-col items-center justify-center gap-1 rounded-md px-1 text-xs font-semibold transition-colors ${
+              className={`relative flex min-h-14 flex-col items-center justify-center gap-1 rounded-2xl px-1 text-xs font-semibold transition-all duration-200 ${
                 isActive
-                  ? "bg-indigo4 text-indigo11 dark:bg-dark-indigo4 dark:text-dark-indigo11"
-                  : "text-gray11 hover:bg-gray4 hover:text-indigo11 dark:text-gray7 dark:hover:bg-dark-slate4 dark:hover:text-dark-indigo11"
+                  ? "-translate-y-1 bg-white/85 text-indigo11 shadow-[0_10px_28px_rgba(63,81,181,0.24),inset_0_1px_0_rgba(255,255,255,0.85)] ring-1 ring-indigo6/60 dark:bg-dark-slate2/90 dark:text-dark-indigo11 dark:shadow-[0_10px_28px_rgba(0,0,0,0.35),inset_0_1px_0_rgba(255,255,255,0.08)] dark:ring-dark-indigo6/70"
+                  : "text-gray11 hover:bg-white/45 hover:text-indigo11 dark:text-gray7 dark:hover:bg-white/10 dark:hover:text-dark-indigo11"
               }`}
             >
-              {link.icon}
+              <span
+                className={`transition-transform duration-200 ${
+                  isActive ? "scale-105" : ""
+                }`}
+              >
+                {link.icon}
+              </span>
               <span>{link.title}</span>
             </Link>
           );

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -1,128 +1,49 @@
 import { useAuth } from "@/context/AuthContext";
-import {
-  Avatar,
-  Button,
-  Drawer,
-  DrawerBody,
-  DrawerCloseButton,
-  DrawerContent,
-  DrawerFooter,
-  DrawerHeader,
-  DrawerOverlay,
-  IconButton,
-  useColorMode,
-  useDisclosure,
-} from "@chakra-ui/react";
-import {
-  ArrowLeftStartOnRectangleIcon,
-  Bars4Icon,
-} from "@heroicons/react/24/outline";
-import { blueDark, gray } from "@radix-ui/colors";
-import React, { memo } from "react";
+import { UserCircleIcon } from "@heroicons/react/24/outline";
+import { memo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { navLinks } from "./links";
 
 function MobileNav() {
-  const { isOpen, onOpen, onClose } = useDisclosure();
-  const btnRef = React.useRef<HTMLButtonElement>(null);
-  const { colorMode } = useColorMode();
   const { pathname } = useLocation();
-  const { currentUserDetails, logOut } = useAuth();
+  const { currentUserDetails } = useAuth();
   if (!currentUserDetails) return null;
 
-  return (
-    <>
-      <IconButton
-        aria-label="open menu"
-        ref={btnRef}
-        variant={"ghost"}
-        icon={<Bars4Icon className="size-5" />}
-        onClick={onOpen}
-      >
-        Open
-      </IconButton>
-      <Drawer
-        isOpen={isOpen}
-        placement="left"
-        onClose={onClose}
-        finalFocusRef={btnRef}
-        size={"xs"}
-      >
-        <DrawerOverlay />
-        <DrawerContent>
-          <DrawerCloseButton />
-          <DrawerHeader
-            bg={colorMode === "dark" ? blueDark.blue2 : gray.gray2}
-          ></DrawerHeader>
-          <DrawerBody
-            bg={colorMode === "dark" ? blueDark.blue2 : gray.gray2}
-            className="flex flex-col items-center text-center"
-          >
-            <div className="space-y-2">
-              <Link to={"/profile"} className="select-none">
-                <Avatar
-                  size={"xl"}
-                  src={currentUserDetails.avatarURL}
-                  name={currentUserDetails.name}
-                />
-              </Link>
-              <div className="relative flex flex-col ">
-                <div className="text-lg font-semibold">
-                  {currentUserDetails.name}
-                </div>
-                <div className=" text-sm italic text-dark-gray5 dark:text-gray6">
-                  {currentUserDetails.about}
-                </div>
-              </div>
-            </div>
+  const mobileNavLinks = [
+    ...navLinks,
+    {
+      value: "/profile",
+      icon: <UserCircleIcon className="size-6" />,
+      title: "Profile",
+    },
+  ];
 
-            <nav className="my-auto flex flex-col items-center gap-4">
-              {navLinks.map((link) => (
-                <Link
-                  to={link.value}
-                  key={link.value}
-                  className={`
-                  flex items-center gap-3 rounded-lg transition-colors hover:text-indigo-600 dark:hover:text-indigo-500 
-                  ${
-                    pathname.split("/").includes(link.value.substring(1))
-                      ? "text-indigo-500"
-                      : ""
-                  }`}
-                >
-                  {link.icon}
-                  <span className="text-lg font-semibold ">{link.title}</span>
-                </Link>
-              ))}
-            </nav>
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-slate4 dark:bg-dark-blue2 md:hidden">
+      <div className="grid grid-cols-4 gap-1">
+        {mobileNavLinks.map((link) => {
+          const isActive = pathname
+            .split("/")
+            .includes(link.value.substring(1));
+
+          return (
             <Link
-              to={"/login"}
-              onClick={() => {
-                logOut();
-              }}
-              className="mt-auto flex transition-all"
+              to={link.value}
+              key={link.value}
+              aria-current={isActive ? "page" : undefined}
+              className={`flex min-h-12 flex-col items-center justify-center gap-1 rounded-md px-1 text-xs font-semibold transition-colors ${
+                isActive
+                  ? "bg-indigo4 text-indigo11 dark:bg-dark-indigo4 dark:text-dark-indigo11"
+                  : "text-gray11 hover:bg-gray4 hover:text-indigo11 dark:text-gray7 dark:hover:bg-dark-slate4 dark:hover:text-dark-indigo11"
+              }`}
             >
-              <Button
-                variant={"ghost"}
-                aria-label="log out"
-                size={"lg"}
-                leftIcon={<ArrowLeftStartOnRectangleIcon className="size-6 " />}
-                className=""
-              >
-                Log out
-              </Button>
+              {link.icon}
+              <span>{link.title}</span>
             </Link>
-          </DrawerBody>
-          <DrawerFooter
-            bg={colorMode === "dark" ? blueDark.blue2 : gray.gray2}
-            className="items-center justify-center"
-          >
-            <span className="text-xs text-gray-600 dark:text-gray-400">
-              VChat © {new Date().getFullYear()}
-            </span>
-          </DrawerFooter>
-        </DrawerContent>
-      </Drawer>
-    </>
+          );
+        })}
+      </div>
+    </nav>
   );
 }
 

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -1,5 +1,6 @@
 import { useAuth } from "@/context/AuthContext";
 import { UserCircleIcon } from "@heroicons/react/24/outline";
+import { UserCircleIcon as UserCircleIconSolid } from "@heroicons/react/24/solid";
 import { memo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { navLinks } from "./links";
@@ -14,6 +15,7 @@ function MobileNav() {
     {
       value: "/profile",
       icon: <UserCircleIcon className="size-6" />,
+      activeIcon: <UserCircleIconSolid className="size-6" />,
       title: "Profile",
     },
   ];
@@ -37,7 +39,7 @@ function MobileNav() {
                   : "text-gray11 hover:bg-gray4 hover:text-indigo11 dark:text-gray7 dark:hover:bg-dark-slate4 dark:hover:text-dark-indigo11"
               }`}
             >
-              {link.icon}
+              {isActive ? link.activeIcon : link.icon}
               <span>{link.title}</span>
             </Link>
           );

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -19,6 +19,10 @@ const Navbar = () => {
       <MyProfile />
       <div className="flex w-full flex-col items-center justify-around gap-2 ">
         {navLinks.map((tab, i) => {
+          const isActive = pathname
+            .split("/")
+            .includes(tab.value.substring(1));
+
           return (
             <Tooltip
               key={i}
@@ -36,9 +40,7 @@ const Navbar = () => {
               <Link to={tab.value} className="relative mb-2">
                 <div
                   className={` absolute -left-1 bottom-0  h-full w-1 rounded-full  bg-dark-indigo10 transition-opacity ${
-                    pathname.split("/").includes(tab.value.substring(1))
-                      ? "visible"
-                      : "invisible"
+                    isActive ? "visible" : "invisible"
                   }`}
                 />
                 <IconButton
@@ -47,7 +49,7 @@ const Navbar = () => {
                   whileHover={{ scale: 1.01 }}
                   whileTap={{ scale: 0.98 }}
                   aria-label={tab.title}
-                  icon={tab.icon}
+                  icon={isActive ? tab.activeIcon : tab.icon}
                   size={"sm"}
                   ml={1}
                 />

--- a/src/components/Navbar/links.tsx
+++ b/src/components/Navbar/links.tsx
@@ -3,21 +3,31 @@ import {
   Cog6ToothIcon,
   UsersIcon,
 } from "@heroicons/react/24/outline";
+import {
+  ChatBubbleBottomCenterTextIcon as ChatBubbleBottomCenterTextIconSolid,
+  Cog6ToothIcon as Cog6ToothIconSolid,
+  UsersIcon as UsersIconSolid,
+} from "@heroicons/react/24/solid";
 
 export const navLinks = [
   {
     value: "/chats",
     icon: <ChatBubbleBottomCenterTextIcon className="size-6 md:size-5" />,
+    activeIcon: (
+      <ChatBubbleBottomCenterTextIconSolid className="size-6 md:size-5" />
+    ),
     title: "Chats",
   },
   {
     value: "/users",
     icon: <UsersIcon className="size-6 md:size-5" />,
+    activeIcon: <UsersIconSolid className="size-6 md:size-5" />,
     title: "Users",
   },
   {
     value: "/settings",
     icon: <Cog6ToothIcon className="size-6 md:size-5" />,
+    activeIcon: <Cog6ToothIconSolid className="size-6 md:size-5" />,
     title: "Settings",
   },
 ];

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -11,7 +11,6 @@ import {
   useDisclosure,
 } from "@chakra-ui/react";
 
-import MobileNav from "@/components/Navbar/MobileNav";
 import { UserGroupIcon } from "@heroicons/react/24/solid";
 import { indigo, indigoDark } from "@radix-ui/colors";
 import { motion } from "framer-motion";
@@ -49,9 +48,7 @@ export function SideBarHeader({ title, className }: SideBarHeaderProps) {
       }
     >
       <span className="relative flex h-full w-full items-center justify-between ">
-        <div className="visible mt-2 md:invisible">
-          <MobileNav />
-        </div>
+        <div className="h-10 w-10 md:hidden" aria-hidden="true" />
 
         <span>{title}</span>
         <div className="flex items-center gap-3">

--- a/src/layouts/AuthenticatedLayout.tsx
+++ b/src/layouts/AuthenticatedLayout.tsx
@@ -8,7 +8,7 @@ interface AuthenticatedLayoutProps {
 
 function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
   return (
-    <div className="fixed inset-0 flex flex-col-reverse pb-[5.75rem] md:flex-row md:pb-0">
+    <div className="fixed inset-0 flex flex-col-reverse pb-[4.5rem] md:flex-row md:pb-0">
       <Navbar />
       {children}
       <MobileNav />

--- a/src/layouts/AuthenticatedLayout.tsx
+++ b/src/layouts/AuthenticatedLayout.tsx
@@ -8,7 +8,7 @@ interface AuthenticatedLayoutProps {
 
 function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
   return (
-    <div className="fixed inset-0 flex flex-col-reverse pb-[4.5rem] md:flex-row md:pb-0">
+    <div className="fixed inset-0 flex flex-col-reverse pb-[5.75rem] md:flex-row md:pb-0">
       <Navbar />
       {children}
       <MobileNav />

--- a/src/layouts/AuthenticatedLayout.tsx
+++ b/src/layouts/AuthenticatedLayout.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import MobileNav from "../components/Navbar/MobileNav";
 import Navbar from "../components/Navbar/Navbar";
 
 interface AuthenticatedLayoutProps {
@@ -7,9 +8,10 @@ interface AuthenticatedLayoutProps {
 
 function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
   return (
-    <div className="fixed inset-0 flex flex-col-reverse md:flex-row">
+    <div className="fixed inset-0 flex flex-col-reverse pb-[4.5rem] md:flex-row md:pb-0">
       <Navbar />
       {children}
+      <MobileNav />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Replace the mobile drawer trigger with a fixed bottom tab bar for Chats, Users, Settings, and Profile.
- Mount the mobile nav from the authenticated layout so it is available across protected screens.
- Add mobile bottom padding to keep content clear of the tab bar and remove the old header placeholder.

## Testing
- Built the app locally to verify the TypeScript and production bundle still pass.
- Checked the authenticated layout wiring and mobile nav structure in the browser at a small viewport.