### PR TITLE
Fix mobile chat background bleed

### DIFF
--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -29,7 +29,7 @@ function MobileNav() {
       style={{
         backgroundColor: navBackground,
       }}
-      className="fixed inset-x-0 bottom-0 z-50 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:bg-dark-blue1 md:hidden"
+      className="fixed inset-x-0 bottom-0 z-50 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 dark:bg-dark-blue1 md:hidden"
     >
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -11,6 +11,7 @@ function MobileNav() {
   const { pathname } = useLocation();
   const { currentUserDetails } = useAuth();
   const navBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+  const navBorder = useColorModeValue(gray.gray5, "rgba(255, 255, 255, 0.08)");
 
   if (!currentUserDetails) return null;
 
@@ -28,8 +29,9 @@ function MobileNav() {
     <nav
       style={{
         backgroundColor: navBackground,
+        borderColor: navBorder,
       }}
-      className="fixed inset-x-0 bottom-0 z-50 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 dark:bg-dark-blue1 md:hidden"
+      className="fixed inset-x-0 bottom-0 z-50 border-t bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 dark:bg-dark-blue1 md:hidden"
     >
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -1,6 +1,8 @@
 import { useAuth } from "@/context/AuthContext";
+import { useColorModeValue } from "@chakra-ui/react";
 import { UserCircleIcon } from "@heroicons/react/24/outline";
 import { UserCircleIcon as UserCircleIconSolid } from "@heroicons/react/24/solid";
+import { blueDark, gray } from "@radix-ui/colors";
 import { memo } from "react";
 import { Link, useLocation } from "react-router-dom";
 import { navLinks } from "./links";
@@ -8,6 +10,9 @@ import { navLinks } from "./links";
 function MobileNav() {
   const { pathname } = useLocation();
   const { currentUserDetails } = useAuth();
+  const navBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+  const navBorder = useColorModeValue(gray.gray5, blueDark.blue6);
+
   if (!currentUserDetails) return null;
 
   const mobileNavLinks = [
@@ -21,7 +26,13 @@ function MobileNav() {
   ];
 
   return (
-    <nav className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-slate4 dark:bg-dark-blue2 md:hidden">
+    <nav
+      style={{
+        backgroundColor: navBackground,
+        borderColor: navBorder,
+      }}
+      className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-blue6 dark:bg-dark-blue1 md:hidden"
+    >
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {
           const isActive = pathname

--- a/src/components/Navbar/MobileNav.tsx
+++ b/src/components/Navbar/MobileNav.tsx
@@ -11,7 +11,6 @@ function MobileNav() {
   const { pathname } = useLocation();
   const { currentUserDetails } = useAuth();
   const navBackground = useColorModeValue(gray.gray2, blueDark.blue1);
-  const navBorder = useColorModeValue(gray.gray5, blueDark.blue6);
 
   if (!currentUserDetails) return null;
 
@@ -29,9 +28,8 @@ function MobileNav() {
     <nav
       style={{
         backgroundColor: navBackground,
-        borderColor: navBorder,
       }}
-      className="fixed inset-x-0 bottom-0 z-50 border-t border-gray5 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:border-dark-blue6 dark:bg-dark-blue1 md:hidden"
+      className="fixed inset-x-0 bottom-0 z-50 bg-gray2 px-2 pb-[calc(0.5rem+env(safe-area-inset-bottom))] pt-2 shadow-[0_-8px_20px_rgba(15,23,42,0.08)] dark:bg-dark-blue1 md:hidden"
     >
       <div className="grid grid-cols-4 gap-1">
         {mobileNavLinks.map((link) => {

--- a/src/features/Room/Messages/MessageInput/MessageInput.tsx
+++ b/src/features/Room/Messages/MessageInput/MessageInput.tsx
@@ -8,12 +8,10 @@ import {
   Portal,
   Spinner,
   Textarea,
-  useColorModeValue,
 } from "@chakra-ui/react";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
-import { blueDark, gray, indigo } from "@radix-ui/colors";
 import { Models } from "appwrite";
 import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -66,15 +64,6 @@ const MessageInput = ({}: InputProps) => {
   const { createMessage } = useMessagesContext();
   const [messageBody, setMessageBody] = useState("");
 
-  const inputBackground = useColorModeValue("white", blueDark.blue2);
-  const inputBorder = useColorModeValue(gray.gray6, blueDark.blue6);
-  const inputShadow = useColorModeValue(
-    "0 8px 24px rgba(15, 23, 42, 0.08)",
-    "0 10px 28px rgba(0, 0, 0, 0.26)",
-  );
-  const inputText = useColorModeValue(gray.gray12, gray.gray1);
-  const placeholderColor = useColorModeValue(gray.gray10, gray.gray8);
-  const sendColor = useColorModeValue(indigo.indigo10, indigo.indigo8);
   const { isGroup, isPersonal, roomState, dispatch } = useRoomContext();
   const inputRef = useRef<null | HTMLTextAreaElement>(null);
 
@@ -178,13 +167,7 @@ const MessageInput = ({}: InputProps) => {
         </div>
       )}
       <footer
-        style={{
-          backgroundColor: inputBackground,
-          borderColor: inputBorder,
-          boxShadow: inputShadow,
-          color: inputText,
-        }}
-        className="mx-3 mb-[calc(0.75rem+env(safe-area-inset-bottom))] mt-2 flex flex-col items-center justify-start overflow-hidden rounded-2xl border bg-white px-2 py-1 dark:bg-dark-blue2 md:mx-4"
+        className="mx-3 mb-[calc(0.75rem+env(safe-area-inset-bottom))] mt-2 flex flex-col items-center justify-start overflow-hidden rounded-2xl border border-gray5 bg-white px-2 py-1 text-gray12 shadow-[0_8px_24px_rgba(15,23,42,0.08)] dark:border-dark-blue6 dark:bg-dark-blue2 dark:text-gray1 dark:shadow-[0_10px_28px_rgba(0,0,0,0.26)] md:mx-4"
       >
         <form onSubmit={handleSubmit} className="flex w-full self-stretch ">
           <div className="flex min-h-11 w-full items-center gap-1 ps-1 ">
@@ -195,8 +178,7 @@ const MessageInput = ({}: InputProps) => {
                   aria-label="emoji"
                   icon={<FaceSmileIcon className="h-4 w-4" />}
                   size={"sm"}
-                  color={inputText}
-                  className="hidden sm:inline-flex"
+                  className="hidden text-gray12 dark:text-gray1 sm:inline-flex"
                 />
               </PopoverTrigger>
               <Portal>
@@ -224,9 +206,9 @@ const MessageInput = ({}: InputProps) => {
               size={"sm"}
               placeholder="Type a message"
               _placeholder={{
-                color: placeholderColor,
                 opacity: 1,
               }}
+              className="text-gray12 placeholder:text-gray10 dark:text-gray1 dark:placeholder:text-gray8"
               value={messageBody}
               onChange={handleChange}
               onBlur={handleChange}
@@ -236,7 +218,6 @@ const MessageInput = ({}: InputProps) => {
                   handleSubmit();
                 }
               }}
-              color={inputText}
               fontSize="16px"
               lineHeight="1.5"
               minH="36px"
@@ -252,8 +233,9 @@ const MessageInput = ({}: InputProps) => {
             <IconButton
               variant={"ghost"}
               aria-label="send"
-              color={sendColor}
-              icon={<PaperAirplaneIcon className="h-5 w-5" />}
+              icon={
+                <PaperAirplaneIcon className="h-5 w-5 text-indigo10 dark:text-dark-indigo8" />
+              }
               type="submit"
               isDisabled={!messageBody.trim()}
               size={"sm"}

--- a/src/features/Room/Messages/MessageInput/MessageInput.tsx
+++ b/src/features/Room/Messages/MessageInput/MessageInput.tsx
@@ -8,12 +8,12 @@ import {
   Portal,
   Spinner,
   Textarea,
-  useColorMode,
+  useColorModeValue,
 } from "@chakra-ui/react";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
-import { slate } from "@radix-ui/colors";
+import { blueDark, gray, indigo } from "@radix-ui/colors";
 import { Models } from "appwrite";
 import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -64,10 +64,17 @@ const MessageInput = ({}: InputProps) => {
 
   const { selectedChat, recepient } = useChatsContext();
   const { createMessage } = useMessagesContext();
-  if (!selectedChat || !currentUserDetails) return null;
   const [messageBody, setMessageBody] = useState("");
 
-  const { colorMode } = useColorMode();
+  const inputBackground = useColorModeValue("white", blueDark.blue2);
+  const inputBorder = useColorModeValue(gray.gray6, blueDark.blue6);
+  const inputShadow = useColorModeValue(
+    "0 8px 24px rgba(15, 23, 42, 0.08)",
+    "0 10px 28px rgba(0, 0, 0, 0.26)",
+  );
+  const inputText = useColorModeValue(gray.gray12, gray.gray1);
+  const placeholderColor = useColorModeValue(gray.gray10, gray.gray8);
+  const sendColor = useColorModeValue(indigo.indigo10, indigo.indigo8);
   const { isGroup, isPersonal, roomState, dispatch } = useRoomContext();
   const inputRef = useRef<null | HTMLTextAreaElement>(null);
 
@@ -93,6 +100,8 @@ const MessageInput = ({}: InputProps) => {
 
   const handleSubmit = async (e?: React.FormEvent) => {
     e?.preventDefault();
+    if (!selectedChat || !currentUserDetails) return;
+
     setMessageBody("");
     dispatch({ type: RoomActionTypes.EXIT_REPLYING_TO, payload: null });
 
@@ -141,6 +150,8 @@ const MessageInput = ({}: InputProps) => {
     setMessageBody("");
   }, [selectedChat]);
 
+  if (!selectedChat || !currentUserDetails) return null;
+
   return (
     <div className="flex flex-col">
       {roomState.replyingTo && (
@@ -166,9 +177,17 @@ const MessageInput = ({}: InputProps) => {
           />
         </div>
       )}
-      <footer className="mx-4 my-2 flex flex-col items-center justify-start overflow-hidden rounded-3xl bg-gray5 px-2 dark:bg-dark-gray3 dark:text-dark-blue12 ">
+      <footer
+        style={{
+          backgroundColor: inputBackground,
+          borderColor: inputBorder,
+          boxShadow: inputShadow,
+          color: inputText,
+        }}
+        className="mx-3 mb-[calc(0.75rem+env(safe-area-inset-bottom))] mt-2 flex flex-col items-center justify-start overflow-hidden rounded-2xl border bg-white px-2 py-1 dark:bg-dark-blue2 md:mx-4"
+      >
         <form onSubmit={handleSubmit} className="flex w-full self-stretch ">
-          <div className="flex h-full w-full items-center gap-1 ps-1 ">
+          <div className="flex min-h-11 w-full items-center gap-1 ps-1 ">
             <Popover onClose={() => inputRef.current?.focus?.()} isLazy>
               <PopoverTrigger>
                 <IconButton
@@ -176,6 +195,7 @@ const MessageInput = ({}: InputProps) => {
                   aria-label="emoji"
                   icon={<FaceSmileIcon className="h-4 w-4" />}
                   size={"sm"}
+                  color={inputText}
                   className="hidden sm:inline-flex"
                 />
               </PopoverTrigger>
@@ -204,7 +224,8 @@ const MessageInput = ({}: InputProps) => {
               size={"sm"}
               placeholder="Type a message"
               _placeholder={{
-                color: colorMode === "dark" ? "slate.300" : "gray.700",
+                color: placeholderColor,
+                opacity: 1,
               }}
               value={messageBody}
               onChange={handleChange}
@@ -215,7 +236,14 @@ const MessageInput = ({}: InputProps) => {
                   handleSubmit();
                 }
               }}
-              color={colorMode === "dark" ? slate.slate2 : "black"}
+              color={inputText}
+              fontSize="16px"
+              lineHeight="1.5"
+              minH="36px"
+              py={1.5}
+              sx={{
+                WebkitTextSizeAdjust: "100%",
+              }}
               variant={"unstyled"}
               resize={"none"}
               rows={1}
@@ -224,11 +252,12 @@ const MessageInput = ({}: InputProps) => {
             <IconButton
               variant={"ghost"}
               aria-label="send"
-              icon={<PaperAirplaneIcon className="h-4 w-4 text-indigo-600" />}
+              color={sendColor}
+              icon={<PaperAirplaneIcon className="h-5 w-5" />}
               type="submit"
               isDisabled={!messageBody.trim()}
-              size={"xs"}
-              my={2}
+              size={"sm"}
+              my={1}
             />
           </div>
         </form>

--- a/src/features/Room/Messages/MessageInput/MessageInput.tsx
+++ b/src/features/Room/Messages/MessageInput/MessageInput.tsx
@@ -8,10 +8,12 @@ import {
   Portal,
   Spinner,
   Textarea,
+  useColorMode,
 } from "@chakra-ui/react";
 import { XMarkIcon } from "@heroicons/react/20/solid";
 import { FaceSmileIcon } from "@heroicons/react/24/outline";
 import { PaperAirplaneIcon } from "@heroicons/react/24/solid";
+import { blueDark, gray } from "@radix-ui/colors";
 import { Models } from "appwrite";
 import React, { Suspense, lazy, useEffect, useRef, useState } from "react";
 import toast from "react-hot-toast";
@@ -64,6 +66,7 @@ const MessageInput = ({}: InputProps) => {
   const { createMessage } = useMessagesContext();
   const [messageBody, setMessageBody] = useState("");
 
+  const { colorMode } = useColorMode();
   const { isGroup, isPersonal, roomState, dispatch } = useRoomContext();
   const inputRef = useRef<null | HTMLTextAreaElement>(null);
 
@@ -167,7 +170,11 @@ const MessageInput = ({}: InputProps) => {
         </div>
       )}
       <footer
-        className="mx-3 mb-[calc(0.75rem+env(safe-area-inset-bottom))] mt-2 flex flex-col items-center justify-start overflow-hidden rounded-2xl border border-gray5 bg-white px-2 py-1 text-gray12 shadow-[0_8px_24px_rgba(15,23,42,0.08)] dark:border-dark-blue6 dark:bg-dark-blue2 dark:text-gray1 dark:shadow-[0_10px_28px_rgba(0,0,0,0.26)] md:mx-4"
+        style={{
+          backgroundColor: colorMode === "dark" ? blueDark.blue2 : "white",
+          borderColor: colorMode === "dark" ? blueDark.blue6 : gray.gray5,
+        }}
+        className="mx-3 mb-[calc(0.75rem+env(safe-area-inset-bottom))] mt-2 flex flex-col items-center justify-start overflow-hidden rounded-2xl border px-2 py-1 text-gray12 shadow-[0_8px_24px_rgba(15,23,42,0.08)] dark:text-gray1 dark:shadow-[0_10px_28px_rgba(0,0,0,0.26)] md:mx-4"
       >
         <form onSubmit={handleSubmit} className="flex w-full self-stretch ">
           <div className="flex min-h-11 w-full items-center gap-1 ps-1 ">

--- a/src/features/Room/Messages/MessageList.tsx
+++ b/src/features/Room/Messages/MessageList.tsx
@@ -1,6 +1,8 @@
 import { useMessagesContext } from "@/context/MessagesContext";
 import { groupDocumentsByDate, sortByCreatedAtAsc } from "@/lib/utils";
 import { ChatMessage } from "@/types/interfaces";
+import { useColorModeValue } from "@chakra-ui/react";
+import { blueDark, gray } from "@radix-ui/colors";
 import { createContext, memo, useContext, useMemo, useRef } from "react";
 import Message from "./Message/Message";
 
@@ -16,6 +18,7 @@ const MessageListContext = createContext<MessagesContextType>({
 function MessageList({}: MessagesProps) {
   const messageListRef = useRef<HTMLDivElement>(null);
   const { messages } = useMessagesContext();
+  const roomBackground = useColorModeValue(gray.gray2, blueDark.blue1);
   const groupedMessages = useMemo(() => {
     return Object.entries(groupDocumentsByDate(messages)).reduce(
       (acc, [date, messages]) => {
@@ -29,10 +32,12 @@ function MessageList({}: MessagesProps) {
   return (
     <div
       ref={messageListRef}
+      style={{ backgroundColor: roomBackground }}
       className="relative min-w-0 grow self-stretch overflow-y-auto overflow-x-hidden bg-gray2 dark:bg-dark-blue1"
     >
       <div
         id="messages-container"
+        style={{ backgroundColor: roomBackground }}
         className="flex h-full min-w-0 grow flex-col-reverse self-stretch overflow-x-hidden overflow-y-scroll bg-gray2 p-2 pb-4 dark:bg-dark-blue1"
       >
         {messages.length > 0 ? (

--- a/src/features/Room/Messages/MessageList.tsx
+++ b/src/features/Room/Messages/MessageList.tsx
@@ -29,11 +29,11 @@ function MessageList({}: MessagesProps) {
   return (
     <div
       ref={messageListRef}
-      className="relative min-w-0 grow self-stretch overflow-y-auto overflow-x-hidden"
+      className="relative min-w-0 grow self-stretch overflow-y-auto overflow-x-hidden bg-gray2 dark:bg-dark-blue1"
     >
       <div
         id="messages-container"
-        className="flex h-full min-w-0 grow flex-col-reverse self-stretch overflow-x-hidden overflow-y-scroll p-2 pb-4"
+        className="flex h-full min-w-0 grow flex-col-reverse self-stretch overflow-x-hidden overflow-y-scroll bg-gray2 p-2 pb-4 dark:bg-dark-blue1"
       >
         {messages.length > 0 ? (
           <MessageListContext.Provider

--- a/src/features/Room/Room.tsx
+++ b/src/features/Room/Room.tsx
@@ -5,7 +5,8 @@ import { useAuth } from "@/context/AuthContext";
 import { useChatsContext } from "@/context/ChatsContext";
 import { RoomActionTypes, useRoomContext } from "@/context/Room/RoomContext";
 import useRoomSubscription from "@/features/Room/hooks/useRoomSubscription";
-import { Box } from "@chakra-ui/react";
+import { Box, useColorModeValue } from "@chakra-ui/react";
+import { blueDark, gray } from "@radix-ui/colors";
 import useCommand from "../../lib/hooks/useCommand";
 import ChatHeader from "./ChatHeader";
 import MessageInput from "./Messages/MessageInput/MessageInput";
@@ -18,6 +19,8 @@ function Room() {
   const { selectedChat } = useChatsContext();
   const { dispatch } = useRoomContext();
   const [showDetails] = useState(false);
+  const roomBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+
   useCommand("Escape", () => {
     dispatch({
       type: RoomActionTypes.EXIT_SELECTING_MESSAGES,
@@ -33,6 +36,8 @@ function Room() {
   return (
     <>
       <Box
+        bg={roomBackground}
+        style={{ backgroundColor: roomBackground }}
         className={`grid h-full min-w-0 flex-1 grid-rows-[1fr_6fr_0.5fr] bg-gray2 dark:bg-dark-blue1`}
       >
         <ChatHeader key={`header-${selectedChat.$id}`} />

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = ({ children }: SidebarProps) => {
   return (
     <aside
       style={{ backgroundColor: sidebarBackground }}
-      className="relative max-h-full shrink grow basis-[25rem] overflow-auto bg-gray2 px-2 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem]"
+      className="relative max-h-full shrink grow basis-[25rem] overflow-auto bg-gray2 px-2 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem] md:border-r md:border-gray5 md:dark:border-dark-slate3"
     >
       {children}
     </aside>

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import {
+  Avatar,
   IconButton,
   Modal,
   ModalBody,
@@ -15,6 +16,7 @@ import {
 import { UserGroupIcon } from "@heroicons/react/24/solid";
 import { blueDark, gray, indigo, indigoDark } from "@radix-ui/colors";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 import { PlusIcon } from "../../components/Icons";
 import { useAuth } from "../../context/AuthContext";
 import NewGroupForm from "../Groups/NewGroup/NewGroupForm";
@@ -46,6 +48,7 @@ interface SideBarHeaderProps {
 export function SideBarHeader({ title, className }: SideBarHeaderProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { colorMode } = useColorMode();
+  const { currentUserDetails } = useAuth();
   const sidebarBackground = useColorModeValue(gray.gray2, blueDark.blue1);
 
   return (
@@ -57,7 +60,13 @@ export function SideBarHeader({ title, className }: SideBarHeaderProps) {
       }
     >
       <span className="relative flex h-full w-full items-center justify-between ">
-        <div className="h-10 w-10 md:hidden" aria-hidden="true" />
+        <Link to="/profile" className="md:hidden" aria-label="Open profile">
+          <Avatar
+            size="sm"
+            src={currentUserDetails?.avatarURL}
+            name={currentUserDetails?.name}
+          />
+        </Link>
 
         <span>{title}</span>
         <div className="flex items-center gap-3">

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -8,11 +8,12 @@ import {
   ModalOverlay,
   Tooltip,
   useColorMode,
+  useColorModeValue,
   useDisclosure,
 } from "@chakra-ui/react";
 
 import { UserGroupIcon } from "@heroicons/react/24/solid";
-import { indigo, indigoDark } from "@radix-ui/colors";
+import { blueDark, gray, indigo, indigoDark } from "@radix-ui/colors";
 import { motion } from "framer-motion";
 import { PlusIcon } from "../../components/Icons";
 import { useAuth } from "../../context/AuthContext";
@@ -22,9 +23,14 @@ interface SidebarProps {
 }
 const Sidebar = ({ children }: SidebarProps) => {
   const { currentUserDetails } = useAuth();
+  const sidebarBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+
   if (!currentUserDetails) return;
   return (
-    <aside className="relative max-h-full shrink grow basis-[25rem] overflow-auto border-r bg-gray2 px-2 dark:border-dark-slate3 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem]">
+    <aside
+      style={{ backgroundColor: sidebarBackground }}
+      className="relative max-h-full shrink grow basis-[25rem] overflow-auto border-r bg-gray2 px-2 dark:border-dark-slate3 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem]"
+    >
       {children}
     </aside>
   );
@@ -40,8 +46,11 @@ interface SideBarHeaderProps {
 export function SideBarHeader({ title, className }: SideBarHeaderProps) {
   const { isOpen, onOpen, onClose } = useDisclosure();
   const { colorMode } = useColorMode();
+  const sidebarBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+
   return (
     <div
+      style={{ backgroundColor: sidebarBackground }}
       className={
         "sticky left-0 right-0 top-0 z-10 flex h-16  items-center bg-gray2 px-4 font-semibold tracking-widest dark:bg-dark-blue1" +
         className

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = ({ children }: SidebarProps) => {
   return (
     <aside
       style={{ backgroundColor: sidebarBackground }}
-      className="relative max-h-full shrink grow basis-[25rem] overflow-auto border-r bg-gray2 px-2 dark:border-dark-slate3 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem]"
+      className="relative max-h-full shrink grow basis-[25rem] overflow-auto bg-gray2 px-2 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem] md:border-r md:dark:border-dark-slate3"
     >
       {children}
     </aside>

--- a/src/features/Sidebar/Sidebar.tsx
+++ b/src/features/Sidebar/Sidebar.tsx
@@ -29,7 +29,7 @@ const Sidebar = ({ children }: SidebarProps) => {
   return (
     <aside
       style={{ backgroundColor: sidebarBackground }}
-      className="relative max-h-full shrink grow basis-[25rem] overflow-auto bg-gray2 px-2 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem] md:border-r md:dark:border-dark-slate3"
+      className="relative max-h-full shrink grow basis-[25rem] overflow-auto bg-gray2 px-2 dark:bg-dark-blue1 dark:text-gray2 md:max-w-[27rem]"
     >
       {children}
     </aside>

--- a/src/layouts/AuthenticatedLayout.tsx
+++ b/src/layouts/AuthenticatedLayout.tsx
@@ -4,14 +4,22 @@ import Navbar from "../components/Navbar/Navbar";
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode;
+  hideMobileNav?: boolean;
 }
 
-function AuthenticatedLayout({ children }: AuthenticatedLayoutProps) {
+function AuthenticatedLayout({
+  children,
+  hideMobileNav = false,
+}: AuthenticatedLayoutProps) {
   return (
-    <div className="fixed inset-0 flex flex-col-reverse pb-[4.5rem] md:flex-row md:pb-0">
+    <div
+      className={`fixed inset-0 flex flex-col-reverse md:flex-row md:pb-0 ${
+        hideMobileNav ? "pb-0" : "pb-[4.5rem]"
+      }`}
+    >
       <Navbar />
       {children}
-      <MobileNav />
+      {!hideMobileNav && <MobileNav />}
     </div>
   );
 }

--- a/src/layouts/AuthenticatedLayout.tsx
+++ b/src/layouts/AuthenticatedLayout.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import MobileNav from "../components/Navbar/MobileNav";
 import Navbar from "../components/Navbar/Navbar";
+import { useColorModeValue } from "@chakra-ui/react";
+import { blueDark, gray } from "@radix-ui/colors";
 
 interface AuthenticatedLayoutProps {
   children: React.ReactNode;
@@ -11,9 +13,11 @@ function AuthenticatedLayout({
   children,
   hideMobileNav = false,
 }: AuthenticatedLayoutProps) {
+   const navBackground = useColorModeValue(gray.gray2, blueDark.blue1);
   return (
     <div
-      className={`fixed inset-0 flex flex-col-reverse md:flex-row md:pb-0 ${
+      style={{ backgroundColor: navBackground }}
+      className={`fixed inset-0 flex flex-col-reverse md:flex-row md:pb-0 bg-gray2 dark:bg-dark-blue1 ${
         hideMobileNav ? "pb-0" : "pb-[4.5rem]"
       }`}
     >

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -13,7 +13,7 @@ function Chats() {
   const roomBackground = useColorModeValue(gray.gray2, blueDark.blue1);
 
   return (
-    <AuthenticatedLayout>
+    <AuthenticatedLayout hideMobileNav={!!selectedChat}>
       <div className={selectedChat ? "hidden md:contents" : "contents"}>
         <Sidebar>
           <SideBarHeader title={"Chats"} className="" />

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -16,7 +16,7 @@ function Chats() {
         <ConversationList className="" />
       </Sidebar>
       <Box
-        className={`absolute inset-0 flex h-full min-w-0 flex-1 transition-opacity md:relative ${
+        className={`absolute inset-0 isolate flex h-full min-w-0 flex-1 overflow-hidden bg-gray2 transition-opacity dark:bg-dark-blue1 md:relative ${
           selectedChat ? "z-10" : "invisible md:visible"
         }`}
       >

--- a/src/pages/Chats.tsx
+++ b/src/pages/Chats.tsx
@@ -1,7 +1,8 @@
 import { useChatsContext } from "@/context/ChatsContext";
 import MessagesProvider from "@/context/MessagesContext";
 import Room from "@/features/Room/Room";
-import { Box } from "@chakra-ui/react";
+import { Box, useColorModeValue } from "@chakra-ui/react";
+import { blueDark, gray } from "@radix-ui/colors";
 import { RoomProvider } from "../context/Room/RoomContext";
 import ConversationList from "../features/Conversations/ConversationList";
 import Sidebar, { SideBarHeader } from "../features/Sidebar/Sidebar";
@@ -9,15 +10,21 @@ import AuthenticatedLayout from "../layouts/AuthenticatedLayout";
 
 function Chats() {
   const { selectedChat } = useChatsContext();
+  const roomBackground = useColorModeValue(gray.gray2, blueDark.blue1);
+
   return (
     <AuthenticatedLayout>
-      <Sidebar>
-        <SideBarHeader title={"Chats"} className="" />
-        <ConversationList className="" />
-      </Sidebar>
+      <div className={selectedChat ? "hidden md:contents" : "contents"}>
+        <Sidebar>
+          <SideBarHeader title={"Chats"} className="" />
+          <ConversationList className="" />
+        </Sidebar>
+      </div>
       <Box
+        bg={roomBackground}
+        style={{ backgroundColor: roomBackground }}
         className={`absolute inset-0 isolate flex h-full min-w-0 flex-1 overflow-hidden bg-gray2 transition-opacity dark:bg-dark-blue1 md:relative ${
-          selectedChat ? "z-10" : "invisible md:visible"
+          selectedChat ? "z-40" : "invisible md:visible"
         }`}
       >
         <RoomProvider>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ import defaultTheme from "tailwindcss/defaultTheme";
  * @type Config
  */
 export default {
-  darkMode: ["class", ".chakra-ui-dark &"],
+  darkMode: ["class", ".chakra-ui-dark"],
 
   important: true,
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,7 +18,7 @@ import defaultTheme from "tailwindcss/defaultTheme";
  * @type Config
  */
 export default {
-  darkMode: ["class", ".chakra-ui-dark"],
+  darkMode: ["class", ".chakra-ui-dark &"],
 
   important: true,
   content: ["./index.html", "./src/**/*.{js,ts,jsx,tsx}"],


### PR DESCRIPTION
## Summary
- Make the mobile chats overlay opaque and clipped so the conversation list does not show through
- Give the message list and scroller their own background on light and dark modes

## Testing
- Not run (not requested)