### PR TITLE
Optimize chat subscriptions to reduce Appwrite reads

### DIFF
--- a/src/features/Conversations/hooks/useChatsListSubscription.tsx
+++ b/src/features/Conversations/hooks/useChatsListSubscription.tsx
@@ -13,7 +13,7 @@ import {
   IUserDetails,
 } from "@/types/interfaces";
 import { Button, CloseButton } from "@chakra-ui/react";
-import { useEffect } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import toast from "react-hot-toast";
 import { useSWRConfig } from "swr";
 import useConversations from "./useConversations";
@@ -25,22 +25,43 @@ const useChatsListSubscription = () => {
     useChatsContext();
   const { mutate, cache } = useSWRConfig();
   const { shouldAlert } = useUserPrefs();
-  const conversationChannels = conversations.map(
-    (c) =>
-      `databases.${c.$databaseId}.collections.${c.$collectionId}.documents.${c.$id}`,
+  const selectedChatRef = useRef(selectedChat);
+  const updateConversationRef = useRef(updateConversation);
+  const selectConversationRef = useRef(selectConversation);
+  const currentUserDetailsIdRef = useRef(currentUserDetails?.$id);
+  const channelKey = useMemo(
+    () =>
+      (conversations || [])
+        .map(
+          (c) =>
+            `databases.${c.$databaseId}.collections.${c.$collectionId}.documents.${c.$id}`,
+        )
+        .sort()
+        .join("|"),
+    [conversations],
   );
+
+  useEffect(() => {
+    selectedChatRef.current = selectedChat;
+    updateConversationRef.current = updateConversation;
+    selectConversationRef.current = selectConversation;
+    currentUserDetailsIdRef.current = currentUserDetails?.$id;
+  });
 
   //subscribe to all conversations
   useEffect(() => {
+    const conversationChannels = channelKey ? channelKey.split("|") : [];
+    if (!currentUserDetails?.$id || conversationChannels.length === 0) return;
+
     return api.subscribe<IConversation>(conversationChannels, (response) => {
       if (
-        response.payload.changerID === currentUserDetails?.$id ||
+        response.payload.changerID === currentUserDetailsIdRef.current ||
         !response.payload.changeLog
       )
         return;
 
       //return early if payload is selected chat
-      if (selectedChat?.$id === response.payload.$id) return;
+      if (selectedChatRef.current?.$id === response.payload.$id) return;
 
       const isGroup =
         response.payload.$collectionId === SERVER.COLLECTION_ID_GROUPS;
@@ -48,7 +69,7 @@ const useChatsListSubscription = () => {
       const conversation = response.payload;
 
       const handleNewMessage = async (newMessageId: string) => {
-        if (selectedChat?.$id === conversation.$id) return;
+        if (selectedChatRef.current?.$id === conversation.$id) return;
         const newMessage = isGroup
           ? await getGroupMessage(newMessageId)
           : await getChatMessage(newMessageId);
@@ -69,7 +90,7 @@ const useChatsListSubscription = () => {
         const unreadCountKey = `conversations/${conversation.$id}/unread`;
         const unreadCount = getUnreadCount(
           conversation,
-          currentUserDetails?.$id!,
+          currentUserDetailsIdRef.current!,
         );
         mutate(unreadCountKey, unreadCount, { revalidate: false });
 
@@ -79,7 +100,7 @@ const useChatsListSubscription = () => {
         });
 
         //update conversation details in cache
-        updateConversation(conversation);
+        updateConversationRef.current(conversation);
 
         //notify user
         toast(
@@ -128,7 +149,7 @@ const useChatsListSubscription = () => {
                   w={"full"}
                   rounded={"md"}
                   onClick={() => {
-                    selectConversation(
+                    selectConversationRef.current(
                       conversation.$id,
                       isGroup ? undefined : sender.$id,
                     );
@@ -155,7 +176,7 @@ const useChatsListSubscription = () => {
 
       matchAndExecute(changeLog, matchers);
     });
-  }, [conversationChannels]);
+  }, [channelKey, currentUserDetails?.$id, mutate, shouldAlert]);
 };
 
 export default useChatsListSubscription;

--- a/src/features/Conversations/hooks/useConversations.ts
+++ b/src/features/Conversations/hooks/useConversations.ts
@@ -34,6 +34,9 @@ export default function useConversations() {
       onSuccess(data) {
         setCachedChats(data);
       },
+      dedupingInterval: 1000 * 60,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
     },
   );
 

--- a/src/features/Conversations/hooks/useUserChatsSubscription.tsx
+++ b/src/features/Conversations/hooks/useUserChatsSubscription.tsx
@@ -14,8 +14,10 @@ import { useEffect } from "react";
 const useUserChatsSubscription = () => {
   const { currentUser, currentUserDetails } = useAuth();
   const { addConversation, deleteConversation } = useChatsContext();
-  if (!currentUser || !currentUserDetails) return null;
+
   useEffect(() => {
+    if (!currentUser || !currentUserDetails) return;
+
     const unsubscribe = api.subscribe<IUserDetails>(
       `databases.${SERVER.DATABASE_ID}.collections.${SERVER.COLLECTION_ID_USERS}.documents.${currentUserDetails.$id}`,
       (response) => {

--- a/src/features/Room/hooks/useRoomMessages.tsx
+++ b/src/features/Room/hooks/useRoomMessages.tsx
@@ -49,6 +49,7 @@ export default function useRoomMessages() {
       onSuccess(data, key, config) {
         const conversation = cache.get("conversations")
           ?.data as IConversation[];
+        if (!conversation) return;
         const newConversations = conversation.map((c) => {
           if (c.$id === selectedChat?.$id) {
             if (isGroup) {
@@ -60,6 +61,9 @@ export default function useRoomMessages() {
         });
         mutate("conversations", newConversations, { revalidate: false });
       },
+      dedupingInterval: 1000 * 60,
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
     },
   );
 }

--- a/src/features/Room/hooks/useRoomSubscription.ts
+++ b/src/features/Room/hooks/useRoomSubscription.ts
@@ -15,14 +15,14 @@ import {
   IUserDetails,
   USER_DETAILS_CHANGE_LOG_REGEXES,
 } from "@/types/interfaces";
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import useSWROptimistic from "../../../lib/hooks/useSWROptimistic";
 
 const useRoomSubscription = () => {
   const { currentUserDetails } = useAuth();
   const { selectedChat, setSelectedChat, setRecepient, recepient } =
     useChatsContext();
-  const { isGroup, isPersonal, dispatch, roomMessagesKey } = useRoomContext();
+  const { isGroup, isPersonal, roomMessagesKey } = useRoomContext();
   const { update: updateRoomMessages } = useSWROptimistic(roomMessagesKey);
   const { update: updateLastMessage } = useSWROptimistic(
     `conversations/${selectedChat?.$id}/last-message`,
@@ -31,6 +31,19 @@ const useRoomSubscription = () => {
     `details ${selectedChat?.$id}`,
   );
   const { messages } = useMessagesContext();
+  const messagesRef = useRef(messages);
+  const updateRoomMessagesRef = useRef(updateRoomMessages);
+  const updateLastMessageRef = useRef(updateLastMessage);
+  const updateRoomDetailsRef = useRef(updateRoomDetails);
+  const currentUserDetailsIdRef = useRef(currentUserDetails?.$id);
+
+  useEffect(() => {
+    messagesRef.current = messages;
+    updateRoomMessagesRef.current = updateRoomMessages;
+    updateLastMessageRef.current = updateLastMessage;
+    updateRoomDetailsRef.current = updateRoomDetails;
+    currentUserDetailsIdRef.current = currentUserDetails?.$id;
+  });
 
   if (!currentUserDetails) return null;
 
@@ -73,7 +86,7 @@ const useRoomSubscription = () => {
         unsubscribe();
       };
     }
-  }, [recepient]);
+  }, [currentUserDetails?.$id, isGroup, recepient?.$id]);
 
   useEffect(() => {
     if (selectedChat && !isPersonal && currentUserDetails) {
@@ -82,33 +95,32 @@ const useRoomSubscription = () => {
         `databases.${SERVER.DATABASE_ID}.collections.${selectedChat.$collectionId}.documents.${selectedChat.$id}`,
         (response) => {
           if (
-            response.payload.changerID === currentUserDetails.$id ||
+            response.payload.changerID === currentUserDetailsIdRef.current ||
             !response.payload.changeLog
           )
             return;
 
           const changeLog = response.payload.changeLog;
 
-          console.log("response", response);
-
           const handleNewMessage = async (newTextId: string) => {
             const newMessage = isGroup
               ? await getGroupMessage(newTextId)
               : await getChatMessage(newTextId);
-            console.log("newMessage", newMessage);
-            updateRoomMessages(
+            updateRoomMessagesRef.current(
               isGroup
-                ? [newMessage, ...(messages || [])]
-                : [newMessage, ...(messages || [])],
+                ? [newMessage, ...(messagesRef.current || [])]
+                : [newMessage, ...(messagesRef.current || [])],
               { revalidate: false },
             ).then((value: any) => {
-              updateLastMessage((value as DirectMessageDetails[]).at(0));
+              updateLastMessageRef.current(
+                (value as DirectMessageDetails[]).at(0),
+              );
             });
           };
 
           const handleDeleteMessage = (deletedTextId: string) => {
-            updateRoomMessages(
-              messages?.filter((msg) => msg.$id !== deletedTextId),
+            updateRoomMessagesRef.current(
+              messagesRef.current?.filter((msg) => msg.$id !== deletedTextId),
             );
           };
 
@@ -120,8 +132,8 @@ const useRoomSubscription = () => {
               : response.payload.chatMessages.find(
                   (msg: any) => msg.$id === editedTextId,
                 );
-            updateRoomMessages(
-              messages?.map((msg) => {
+            updateRoomMessagesRef.current(
+              messagesRef.current?.map((msg) => {
                 if (msg.$id === editedTextId) {
                   return {
                     ...msg,
@@ -135,10 +147,12 @@ const useRoomSubscription = () => {
           };
 
           const handleReadText = (readTextId: string) => {
-            const readText = messages.find((msg) => msg.$id === readTextId);
+            const readText = messagesRef.current.find(
+              (msg) => msg.$id === readTextId,
+            );
             if (!readText) return;
-            updateRoomMessages(
-              messages.map((msg) => {
+            updateRoomMessagesRef.current(
+              messagesRef.current.map((msg) => {
                 if (msg.$id === readTextId) {
                   return {
                     ...msg,
@@ -153,14 +167,14 @@ const useRoomSubscription = () => {
           };
 
           const handleClearMessages = () => {
-            updateRoomMessages([], { revalidate: false });
-            updateLastMessage(undefined);
+            updateRoomMessagesRef.current([], { revalidate: false });
+            updateLastMessageRef.current(undefined);
           };
 
           const handleLike = (messageId: string) => {
             const newLiker = response.payload.changerID;
-            updateRoomMessages(
-              messages.map((msg) => {
+            updateRoomMessagesRef.current(
+              messagesRef.current.map((msg) => {
                 if (msg.$id === messageId) {
                   return {
                     ...msg,
@@ -177,7 +191,7 @@ const useRoomSubscription = () => {
               { revalidate: false },
             ).then((value: any) => {
               //remove liked suffix
-              updateRoomMessages(
+              updateRoomMessagesRef.current(
                 value.map((msg: any) => {
                   if (msg.$id === messageId + "-liked") {
                     return { ...msg, $id: messageId };
@@ -190,8 +204,8 @@ const useRoomSubscription = () => {
 
           const handleUnlike = (messageId: string) => {
             const newUnliker = response.payload.changerID;
-            updateRoomMessages(
-              messages.map((msg) => {
+            updateRoomMessagesRef.current(
+              messagesRef.current.map((msg) => {
                 if (msg.$id === messageId) {
                   return {
                     ...msg,
@@ -208,7 +222,7 @@ const useRoomSubscription = () => {
               { revalidate: false },
             ).then((value: any) => {
               //remove unliked suffix
-              updateRoomMessages(
+              updateRoomMessagesRef.current(
                 value.map((msg: any) => {
                   if (msg.$id === messageId + "-unliked") {
                     return { ...msg, $id: messageId };
@@ -221,7 +235,7 @@ const useRoomSubscription = () => {
 
           const handleOtherChanges = () => {
             setSelectedChat(response.payload);
-            updateRoomDetails(response.payload);
+            updateRoomDetailsRef.current(response.payload);
           };
 
           const matchers = new Map();
@@ -286,15 +300,11 @@ const useRoomSubscription = () => {
       };
     }
   }, [
-    currentUserDetails,
-    dispatch,
+    currentUserDetails?.$id,
     isGroup,
     isPersonal,
-    messages,
-    selectedChat,
-    updateLastMessage,
-    updateRoomMessages,
-    updateRoomDetails,
+    selectedChat?.$collectionId,
+    selectedChat?.$id,
   ]);
 };
 

--- a/src/services/userDetailsService.ts
+++ b/src/services/userDetailsService.ts
@@ -227,21 +227,30 @@ export async function searchUsers(name: string) {
 
 export async function getConversations(userDetailsID: string) {
   if (!userDetailsID) return [];
-  let conversations: (GroupChatDetails | DirectChatDetails)[] = [];
-  const res = await Promise.allSettled([
-    getUserChats(userDetailsID),
-    getUserGroups(userDetailsID),
-  ]);
+  const userDetails = (await api.getDocument(
+    SERVER.DATABASE_ID,
+    SERVER.COLLECTION_ID_USERS,
+    userDetailsID,
+  )) as IUserDetails;
 
-  conversations = ([] as (DirectChatDetails | GroupChatDetails)[]).concat(
-    ...(res
-      .map((resVal) =>
-        resVal.status === "fulfilled" ? resVal.value : undefined,
-      )
-      .filter((x) => x !== undefined) as (
-      | DirectChatDetails
-      | GroupChatDetails
-    )[][]),
+  const chatIDs = userDetails.chats.map((chat) => chat.$id);
+  let chats: DirectChatDetails[] = [];
+  if (chatIDs.length > 0) {
+    const { documents } = await api.listDocuments(
+      SERVER.DATABASE_ID,
+      SERVER.COLLECTION_ID_CHATS,
+      [
+        Query.equal("$id", [...chatIDs]),
+        Query.orderDesc("$updatedAt"),
+        Query.limit(100),
+      ],
+    );
+    chats = documents as DirectChatDetails[];
+  }
+
+  const conversations = ([] as (DirectChatDetails | GroupChatDetails)[]).concat(
+    chats,
+    userDetails.groups || [],
   );
 
   return sortConversations(conversations);


### PR DESCRIPTION
## Summary
- Stabilized realtime subscriptions so they no longer resubscribe on every message or render-driven state change.
- Reduced SWR revalidation noise on chat and room data where realtime updates already keep the UI fresh.
- Removed a duplicate user-document read in `getConversations()`.

## Testing
- Build passed locally.
- Lint passed locally.